### PR TITLE
fix(resourceName): fix name not match with resourceName validation

### DIFF
--- a/pkg/tfkschema/name_mapper.go
+++ b/pkg/tfkschema/name_mapper.go
@@ -150,7 +150,7 @@ func ToTerraformResourceType(obj runtime.Object) string {
 func ToTerraformResourceName(obj runtime.Object) string {
 	meta := k8sutils.ObjectMeta(obj)
 
-	return NormalizeTerraformName(meta.Name, false, "")
+	return "resource_" + NormalizeTerraformName(meta.Name, false, "")
 }
 
 // NormalizeTerraformMapKey converts Map keys to a form suitable for Terraform


### PR DESCRIPTION
When create deployment with name begin with digit, terraform would complaint about a resource name must start with letter, so this work around should work fine.
